### PR TITLE
Fix error: Executable doesn't exist

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.48.2-focal
+FROM mcr.microsoft.com/playwright:v1.49.1-noble
 
 WORKDIR /workspace
 ADD package.json /workspace/


### PR DESCRIPTION
at /ms-playwright/chromium_headless_shell-1148/chrome-linux/headless_shell\n Looks like Playwright Test or Playwright was just updated to 1.49.1. Please update docker image as well.
- current: mcr.microsoft.com/playwright:v1.48.2-focal
- required: mcr.microsoft.com/playwright:v1.49.1-focal